### PR TITLE
Replaced deprecated Avalonia.Svg package with Svg.Controls.Avalonia.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Base packages -->
-    <PackageVersion Include="Avalonia.Svg" Version="11.3.0" />
+    <PackageVersion Include="Svg.Controls.Avalonia" Version="11.3.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <!-- Avalonia packages -->

--- a/src/LiveMarkdown.Avalonia/LiveMarkdown.Avalonia.csproj
+++ b/src/LiveMarkdown.Avalonia/LiveMarkdown.Avalonia.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia"/>
-        <PackageReference Include="Avalonia.Svg" />
+        <PackageReference Include="Svg.Controls.Avalonia" />
         <PackageReference Include="Markdig"/>
         <PackageReference Include="PolySharp">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
On the NuGet page for Avalonia.Svg, it is indicated that it is deprecated and that Svg.Controls.Avalonia should be used: https://www.nuget.org/packages/Avalonia.Svg/