### PR TITLE
Updated Svg.Controls.Avalonia to version 11.3.0.1.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Base packages -->
-    <PackageVersion Include="Svg.Controls.Avalonia" Version="11.3.0" />
+    <PackageVersion Include="Svg.Controls.Avalonia" Version="11.3.0.1" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <!-- Avalonia packages -->


### PR DESCRIPTION
In my previous PR, I had set it to the same version as other Avalonia package, but 11.3.0 doesn't actually exists for Svg.Control.Avalonia. This didn't prevent building (as it was falling back on 11.3.0.1) but to avoid unnecessary warnings, I prefer updating it.

Sorry for the double PR 😓 