### PR TITLE
feat: allow custom configuration of Markdown pipeline

### DIFF
--- a/src/LiveMarkdown.Avalonia/MarkdownRenderer.cs
+++ b/src/LiveMarkdown.Avalonia/MarkdownRenderer.cs
@@ -123,10 +123,22 @@ public partial class MarkdownRenderer : Control
     private ObservableStringBuilderChangedEventArgs? pendingChange;
 
     private readonly DocumentNode documentNode;
-    private readonly MarkdownPipeline pipeline = new MarkdownPipelineBuilder()
-        .UseAdvancedExtensions()
-        .UseCodeBlockSpanFixer()
-        .Build();
+    private readonly MarkdownPipeline pipeline = CreatePipeline();
+
+    /// <summary>
+    /// Optional callback to configure the Markdig pipeline before it is built.
+    /// Set this before any MarkdownRenderer instances are created.
+    /// </summary>
+    public static Action<MarkdownPipelineBuilder>? ConfigurePipeline { get; set; }
+
+    private static MarkdownPipeline CreatePipeline()
+    {
+        var builder = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UseCodeBlockSpanFixer();
+        ConfigurePipeline?.Invoke(builder);
+        return builder.Build();
+    }
 
     internal static readonly ParametrizedLogger? VerboseLogger;
 


### PR DESCRIPTION
### Summary

Adds a static `ConfigurePipeline` callback that allows consumers to customize the Markdig `MarkdownPipelineBuilder` before the pipeline is built.

### Motivation

Currently, the Markdig pipeline is hardcoded with `UseAdvancedExtensions()` and `UseCodeBlockSpanFixer()`. There's no way for library consumers to add custom Markdig extensions (e.g., custom block parsers, inline parsers, or other extensions) without forking the library.

### Changes

- Added `MarkdownRenderer.ConfigurePipeline` static property (`Action<MarkdownPipelineBuilder>?`)
- Extracted pipeline creation into a `CreatePipeline()` method that invokes the callback if set

### Usage

```csharp
// Set before creating any MarkdownRenderer instances, e.g. in Program.cs
MarkdownRenderer.ConfigurePipeline = builder =>
{
    builder.Use<MyCustomExtension>();
};
```

### Notes

- The callback is invoked *after* `UseAdvancedExtensions()` and `UseCodeBlockSpanFixer()`, so custom extensions can build on top of the defaults
- Setting the callback after a `MarkdownRenderer` has been instantiated won't affect existing instances