### PR TITLE
Add more registration/unregistration methods in MarkdownNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1>LiveMarkdown.Avalonia</h1>
 
-**High performance, real-time markdown renderer for AI/LLM**
+**High performance, real-time Markdown renderer for AI/LLM**
 
 <p align="center">
   <a href="https://deepwiki.com/DearVa/LiveMarkdown.Avalonia"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
@@ -156,6 +156,13 @@ using LiveMarkdown.Avalonia;
 
 MarkdownNode.Register<MathInlineNode>();
 MarkdownNode.Register<MathBlockNode>(); // This is also required for block-level LaTeX support, e.g. $$...$$
+
+// Also, you can use the following code to register/unregister multiple nodes at once if needed:
+MarkdownNode.Edit(builder => builder
+    .Register<MathInlineNode>()
+    .Register<MathBlockNode>()
+    // .Unregister<SomeBuiltInNode>() // You can even unregister some built-in nodes if you want to disable certain Markdown features
+);
 ```
 
 ### 5. (Optional) Enable SVG image rendering

--- a/src/LiveMarkdown.Avalonia.Demo/LiveMarkdown.Avalonia.Demo/App.axaml.cs
+++ b/src/LiveMarkdown.Avalonia.Demo/LiveMarkdown.Avalonia.Demo/App.axaml.cs
@@ -1,9 +1,8 @@
+using System.Text.RegularExpressions;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Logging;
 using Avalonia.Markup.Xaml;
-using LiveMarkdown.Avalonia.Demo.ViewModels;
 using LiveMarkdown.Avalonia.Demo.Views;
 
 namespace LiveMarkdown.Avalonia.Demo;
@@ -13,11 +12,13 @@ public partial class App : Application, ILogSink
     public override void Initialize()
     {
         Logger.Sink = this;
-        MarkdownNode.Register<MathInlineNode>();
-        MarkdownNode.Register<MathBlockNode>();
 
         MarkdownRenderer.ConfigurePipeline += x => x.UseMermaid();
-        MarkdownNode.Register<MermaidBlockNode>();
+        MarkdownNode.Edit(builder => builder
+            .Register<MathInlineNode>()
+            .Register<MathBlockNode>()
+            .Register<MermaidBlockNode>()
+        );
 
         AsyncImageLoader.DefaultDecoders =
         [
@@ -59,6 +60,6 @@ public partial class App : Application, ILogSink
         Log(level, area, source, formattedMessage);
     }
 
-    [System.Text.RegularExpressions.GeneratedRegex(@"\{[^\}]+\}")]
-    private static partial System.Text.RegularExpressions.Regex LogTemplateRegex();
+    [GeneratedRegex(@"\{[^\}]+\}")]
+    private static partial Regex LogTemplateRegex();
 }

--- a/src/LiveMarkdown.Avalonia/Nodes/MarkdownNode.cs
+++ b/src/LiveMarkdown.Avalonia/Nodes/MarkdownNode.cs
@@ -1,4 +1,5 @@
-﻿using Markdig.Syntax;
+﻿using System.Collections.Immutable;
+using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
 // ReSharper disable InconsistentNaming
@@ -7,10 +8,7 @@ namespace LiveMarkdown.Avalonia;
 
 public abstract class MarkdownNode
 {
-    protected static IReadOnlyCollection<IMarkdownNodeFactory> NodeFactories => NodeFactoriesSet;
-
-    private readonly static HashSet<IMarkdownNodeFactory> NodeFactoriesSet =
-    [
+    protected static ImmutableHashSet<IMarkdownNodeFactory> NodeFactories { get; private set; } = ImmutableHashSet.Create<IMarkdownNodeFactory>(
         new MarkdownNodeFactory<AutolinkInlineNode>(),
         new MarkdownNodeFactory<CodeInlineNode>(),
         new MarkdownNodeFactory<ContainerInlineNode<ContainerInline>>(),
@@ -21,7 +19,6 @@ public abstract class MarkdownNode
         new MarkdownNodeFactory<LinkInlineNode>(),
         new MarkdownNodeFactory<LiteralInlineNode>(),
         new MarkdownNodeFactory<TaskListNode>(),
-
         new MarkdownNodeFactory<AlertBlockNode>(),
         new MarkdownNodeFactory<CodeBlockNode>(),
         new MarkdownNodeFactory<HeadingBlockNode>(),
@@ -31,32 +28,34 @@ public abstract class MarkdownNode
         new MarkdownNodeFactory<QuoteBlockNode>(),
         new MarkdownNodeFactory<TableCellNode>(),
         new MarkdownNodeFactory<TableNode>(),
-        new MarkdownNodeFactory<ThematicBreakBlockNode>(),
-    ];
+        new MarkdownNodeFactory<ThematicBreakBlockNode>()
+    );
 
-    public static void Unregister(IMarkdownNodeFactory factory)
-    {
-        NodeFactoriesSet.Remove(factory);
-    }
-
-    public static void Unregister<TNode>() where TNode : MarkdownNode, new()
-    {
-        NodeFactoriesSet.RemoveWhere(fac => fac is MarkdownNodeFactory<TNode>);
-    }
-
-    public static void UnregisterWhere(Predicate<IMarkdownNodeFactory> predicate)
-    {
-        NodeFactoriesSet.RemoveWhere(predicate);
-    }
-
-    public static void Register<TNode>(IMarkdownNodeFactory<TNode> factory) where TNode : MarkdownNode, new()
-    {
-        NodeFactoriesSet.Add(factory);
-    }
-
+    /// <summary>
+    /// Register a single node factory to the pipeline. This allows for custom node factories to be added to the pipeline, enabling support for custom Markdown syntax or behavior.
+    /// </summary>
+    /// <remarks>
+    /// If you want to register multiple node factories, consider using the <see cref="Edit"/> method to configure the pipeline in a single call, which can be more efficient and easier to read.
+    /// </remarks>
+    /// <typeparam name="TNode"></typeparam>
     public static void Register<TNode>() where TNode : MarkdownNode, new()
     {
-        NodeFactoriesSet.Add(new MarkdownNodeFactory<TNode>());
+        Edit(builder => builder.Register<TNode>());
+    }
+
+    /// <summary>
+    /// Edits the pipeline of node factories using the provided builder function.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// MarkdownNode.Edit(builder =&gt;
+    ///     builder.Register&lt;CustomNode&gt;().Unregister&lt;HeadingBlockNode&gt;());
+    /// </code>
+    /// </example>
+    /// <param name="builder">The function to configure the pipeline.</param>
+    public static void Edit(Func<MarkdownNodePipelineBuilder, MarkdownNodePipelineBuilder> builder)
+    {
+        NodeFactories = [..builder(new MarkdownNodePipelineBuilder([..NodeFactories])).RegisteredNodeFactories];
     }
 
     /// <summary>

--- a/src/LiveMarkdown.Avalonia/Nodes/MarkdownNode.cs
+++ b/src/LiveMarkdown.Avalonia/Nodes/MarkdownNode.cs
@@ -34,6 +34,26 @@ public abstract class MarkdownNode
         new MarkdownNodeFactory<ThematicBreakBlockNode>(),
     ];
 
+    public static void Unregister(IMarkdownNodeFactory factory)
+    {
+        NodeFactoriesSet.Remove(factory);
+    }
+
+    public static void Unregister<TNode>() where TNode : MarkdownNode, new()
+    {
+        NodeFactoriesSet.RemoveWhere(fac => fac is MarkdownNodeFactory<TNode>);
+    }
+
+    public static void UnregisterWhere(Predicate<IMarkdownNodeFactory> predicate)
+    {
+        NodeFactoriesSet.RemoveWhere(predicate);
+    }
+
+    public static void Register<TNode>(IMarkdownNodeFactory<TNode> factory) where TNode : MarkdownNode, new()
+    {
+        NodeFactoriesSet.Add(factory);
+    }
+
     public static void Register<TNode>() where TNode : MarkdownNode, new()
     {
         NodeFactoriesSet.Add(new MarkdownNodeFactory<TNode>());

--- a/src/LiveMarkdown.Avalonia/Nodes/MarkdownNodePipelineBuilder.cs
+++ b/src/LiveMarkdown.Avalonia/Nodes/MarkdownNodePipelineBuilder.cs
@@ -1,0 +1,68 @@
+﻿namespace LiveMarkdown.Avalonia;
+
+/// <summary>
+/// Provides a builder for configuring the pipeline of Markdown node factories in Fluent style. This allows for easy registration and unregistration of node factories, enabling customization of the Markdown parsing process.
+/// </summary>
+public readonly ref struct MarkdownNodePipelineBuilder
+{
+    public HashSet<IMarkdownNodeFactory> RegisteredNodeFactories { get; }
+
+    internal MarkdownNodePipelineBuilder(HashSet<IMarkdownNodeFactory> registeredNodeFactories)
+    {
+        RegisteredNodeFactories = registeredNodeFactories;
+    }
+
+    /// <summary>
+    /// Registers a single node factory to the pipeline. This allows for custom node factories to be added to the pipeline, enabling support for custom Markdown syntax or behavior.
+    /// </summary>
+    /// <typeparam name="TNode"></typeparam>
+    /// <param name="factory"></param>
+    /// <returns></returns>
+    public MarkdownNodePipelineBuilder Register<TNode>(IMarkdownNodeFactory<TNode> factory) where TNode : MarkdownNode
+    {
+        RegisteredNodeFactories.Add(factory);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a new instance of a node factory to the pipeline. This uses the standard <see cref="MarkdownNodeFactory{TNode}"/> implementation to create a factory based on the generic type parameter.
+    /// </summary>
+    /// <typeparam name="TNode"></typeparam>
+    /// <returns></returns>
+    public MarkdownNodePipelineBuilder Register<TNode>() where TNode : MarkdownNode, new()
+    {
+        RegisteredNodeFactories.Add(new MarkdownNodeFactory<TNode>());
+        return this;
+    }
+
+    /// <summary>
+    /// Unregisters a node factory from the pipeline. This allows for custom node factories to be removed from the pipeline, enabling support for custom Markdown syntax or behavior.
+    /// </summary>
+    /// <param name="factory"></param>
+    /// <returns></returns>
+    public MarkdownNodePipelineBuilder Unregister(IMarkdownNodeFactory factory)
+    {
+        RegisteredNodeFactories.Remove(factory);
+        return this;
+    }
+
+    /// <summary>
+    /// Unregisters a node factory of the specified type from the pipeline. This uses the standard <see cref="MarkdownNodeFactory{TNode}"/> implementation to identify the factory to remove based on the generic type parameter.
+    /// </summary>
+    public MarkdownNodePipelineBuilder Unregister<TNode>() where TNode : MarkdownNode, new()
+    {
+        RegisteredNodeFactories.RemoveWhere(f => f is MarkdownNodeFactory<TNode>);
+        return this;
+    }
+
+    /// <summary>
+    /// Unregisters node factories from the pipeline based on a predicate. This allows for more complex logic to determine which factories to remove, such as removing all factories that handle a certain type of Markdown object.
+    /// </summary>
+    /// <param name="predicate"></param>
+    /// <returns></returns>
+    public MarkdownNodePipelineBuilder UnregisterWhere(Predicate<IMarkdownNodeFactory> predicate)
+    {
+        RegisteredNodeFactories.RemoveWhere(predicate);
+        return this;
+    }
+}


### PR DESCRIPTION
Add extra static methods to `MarkdownNode`:
- `Unregister(IMarkdownNodeFactory)`
- `Unregister<TNode>()`
- `UnregisterWhere(Predicate<IMarkdownNodeFactory>)`
- `Register<TNode>(IMarkdownNodeFactory<TNode>)`

They should be useful when users of this library wants to replace built-in markdown nodes with custom implementations.