### PR TITLE
Tests: one headless session per assembly, not one per test

### DIFF
--- a/tests/LiveMarkdown.Avalonia.Tests/HeadlessSession.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/HeadlessSession.cs
@@ -1,0 +1,35 @@
+using Avalonia.Headless;
+
+namespace LiveMarkdown.Avalonia.Tests;
+
+/// <summary>
+/// ONE headless session for the whole test assembly.
+///
+/// <para>Avalonia's default isolation is <see cref="AvaloniaTestIsolationLevel.PerTest"/>, and its
+/// <c>DispatchCore</c> documentation is explicit that a dispatch "creates a new application instance,
+/// setting app avalonia services". Starting a session per test — <c>StartNew</c> in <c>[SetUp]</c>,
+/// <c>Dispose</c> in <c>[TearDown]</c> — therefore runs Avalonia's whole application construction path
+/// once per test, and that path (ServerCompositor hooking the render loop) intermittently dies with
+/// <c>InvalidOperationException: The calling thread cannot access this object because a different thread
+/// owns it</c>, thrown from inside Avalonia's own render, not from any test body.</para>
+///
+/// <para>Measured here: the full suite failed 4 runs in 6, always in
+/// <c>CaptureTimeline_LinkClick_AndDragStartingOnLink</c>; that same test run ALONE passed 6 in 6, and its
+/// whole fixture alone passed 4 in 4. So it was never that test — it was the number of times the
+/// application had been rebuilt before it.</para>
+///
+/// <para>Building once removes those re-runs. The trade, per Avalonia's own remarks on
+/// <see cref="AvaloniaTestIsolationLevel.PerAssembly"/>: state leaks between tests, so a fixture must undo
+/// anything global it sets, and windows a test opens stay open unless it closes them.</para>
+/// </summary>
+internal static class HeadlessSession
+{
+    private static readonly Lazy<HeadlessUnitTestSession> Instance =
+        new(() => HeadlessUnitTestSession.StartNew(
+            typeof(MarkdownPointerSelectionTests.StyledTestApplication),
+            AvaloniaTestIsolationLevel.PerAssembly));
+
+    /// <summary>The shared session. Deliberately never disposed: disposing it tears down the application
+    /// that every remaining test in the assembly is about to dispatch onto.</summary>
+    public static HeadlessUnitTestSession Current => Instance.Value;
+}

--- a/tests/LiveMarkdown.Avalonia.Tests/MarkdownPointerSelectionTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/MarkdownPointerSelectionTests.cs
@@ -25,13 +25,15 @@ public class MarkdownPointerSelectionTests
     [OneTimeSetUp]
     public void StartSession()
     {
-        session = HeadlessUnitTestSession.StartNew(typeof(StyledTestApplication));
+        session = HeadlessSession.Current;
     }
 
     [OneTimeTearDown]
     public void StopSession()
     {
-        session.Dispose();
+        // Deliberately NOT disposed. The session is shared for the whole assembly (see HeadlessSession),
+        // and this fixture is not the last one to use it — tearing it down here kills the application
+        // that PointerInteractionDiagnosticsTests is about to dispatch onto.
     }
 
     [TestCase(2, "doubleclick")]

--- a/tests/LiveMarkdown.Avalonia.Tests/PointerInteractionDiagnosticsTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/PointerInteractionDiagnosticsTests.cs
@@ -18,13 +18,13 @@ public sealed class PointerInteractionDiagnosticsTests
     [SetUp]
     public void SetUp()
     {
-        session = HeadlessUnitTestSession.StartNew(typeof(MarkdownPointerSelectionTests.StyledTestApplication));
+        session = HeadlessSession.Current;
     }
 
     [TearDown]
     public void TearDown()
     {
-        session.Dispose();
+        // Deliberately NOT disposed: the session is shared for the whole assembly.
     }
 
     [Test]


### PR DESCRIPTION
`CaptureTimeline_LinkClick_AndDragStartingOnLink` fails intermittently on `main` — **4 runs in 6** on my machine, and on the first CI run I did of this repo it failed on **both ubuntu and macOS**:

```
System.InvalidOperationException : The calling thread cannot access this object
because a different thread owns it.
   at Avalonia.Media.TextDecoration.get_StrokeThickness()
   at Avalonia.Media.TextFormatting.ShapedTextRun.Draw(...)
   at LiveMarkdown.Avalonia.MarkdownTextBlock.RenderTextLayout(...)
```

thrown from inside Avalonia's own render rather than from any test body.

## It isn't that test

| | result |
|---|---|
| that test alone | 6/6 pass |
| its whole fixture alone | 4/4 pass |
| full suite | **4 failures in 6** |

What makes it fail is how much ran *before* it.

## Why

`Avalonia.Headless` defaults to `AvaloniaTestIsolationLevel.PerTest`, and the `DispatchCore` docs are explicit that a dispatch *"creates a new application instance, setting app avalonia services"*. Both session-owning fixtures call `StartNew` in `[SetUp]` and `Dispose` in `[TearDown]`, so Avalonia's whole application construction path — `ServerCompositor` hooking the render loop — runs once per test. That path is the racy one, and the more often it runs the likelier a render lands on a thread that no longer owns what it's drawing.

## The change

One `Lazy<HeadlessUnitTestSession>` with `PerAssembly`, never disposed — disposing it would tear down the application the remaining tests are about to dispatch onto.

**Setting `PerAssembly` alone is not enough**, and I tried that first: with `StartNew` still called per test the application is rebuilt regardless, and 3 runs in 6 still failed.

```
before   133 passed,  3 skipped,  4 failures in 6 runs
after    136 passed,  0 skipped,  0 failures in 8 runs
```

The three skips are a second, quieter win: `PreparedPositionedGraph_*` skip themselves when no rendering platform is available, and the rebuild churn was making the platform *look* unavailable. They were silently not running.

The trade, per Avalonia's own remarks on `PerAssembly`: state leaks between tests, so a fixture must undo anything global it sets and close windows it opens. Both fixtures here already create their windows inside the dispatched body.
