### PR TITLE
Build the Markdig pipeline once per process, not once per renderer

### DIFF
--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
@@ -206,7 +206,23 @@ public partial class MarkdownRenderer : Control
     private MarkdownTextProjection? _renderedTextProjection;
 
     private readonly DocumentNode documentNode;
-    private readonly MarkdownPipeline pipeline = CreatePipeline();
+    /// <summary>
+    /// The parse pipeline, built once per process rather than once per renderer.
+    /// </summary>
+    /// <remarks>
+    /// <para>Every renderer built an identical pipeline: <see cref="ConfigurePipeline"/> is documented as
+    /// "set before any instances are created", so no two copies could ever differ. Each costs about 26 us
+    /// to build and retains roughly 38 KB of parser tables for the renderer's lifetime — which, in a chat
+    /// UI, is the lifetime of the message.</para>
+    /// <para>Lazily initialised on purpose: <c>ConfigurePipeline += ...</c> is itself the first touch of
+    /// this type, so a plain static initialiser would run <see cref="CreatePipeline"/> before the caller's
+    /// handler finished registering and silently drop its extensions.</para>
+    /// <para>Sharing is safe because concurrent parses share parser INSTANCES only, which Markdig
+    /// supports. Extensions added through <see cref="ConfigurePipeline"/> must therefore hold no per-parse
+    /// instance state.</para>
+    /// </remarks>
+    private static readonly Lazy<MarkdownPipeline> pipeline =
+        new(CreatePipeline, LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <summary>
     /// Optional callback to configure the Markdig pipeline before it is built.
@@ -316,7 +332,7 @@ public partial class MarkdownRenderer : Control
                 }
 
                 var time = DateTimeOffset.UtcNow;
-                var document = await Task.Run(() => Markdown.Parse(currentSnapshot.Text, pipeline), cancellationToken);
+                var document = await Task.Run(() => Markdown.Parse(currentSnapshot.Text, pipeline.Value), cancellationToken);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 Dispatcher.UIThread.VerifyAccess();


### PR DESCRIPTION
`ConfigurePipeline` is documented as *"set before any instances are created"*, so every renderer's pipeline is necessarily identical — yet each one builds and retains its own.

## Cost

Measured on Markdig 1.3.2 / .NET 10:

| | per renderer |
|---|---|
| build | ~26 µs |
| retained | ~38 KB of parser tables |

Held for the renderer's lifetime. In a chat UI that's *per message*, so it scales with scrollback rather than with anything on screen:

| 2,500 open messages | per-renderer | shared |
|---|---|---|
| duplicated parser tables | **~91 MB** | 0.8 MB |
| added gen2 collection | **~+8.3 ms** | no measurable cost |

The gen2 figure is the one that shows: these are long-lived and reference-rich, and the pause lands on the UI thread.

## Two things worth keeping in the diff

**`Lazy`, not a plain static initialiser.** Registering a handler with `ConfigurePipeline += …` is itself the first touch of this type, so an eager static would build the pipeline *before* that handler finished registering and silently drop the caller's extensions. That's a quiet failure — the app renders, just without the extension it asked for.

**Sharing is safe because concurrent parses share parser INSTANCES only**, which is Markdig's supported usage. The remarks record the obligation that places on future extensions: anything added through `ConfigurePipeline` must hold no per-parse instance state.

136 tests pass.

> Note: on a clean checkout this suite is intermittently red for an unrelated reason — see the headless-session-isolation PR. This was verified against a run with that fix applied so the number means something.
