### PR TITLE
Don't invalidate or defer when the builder is rebound

### DIFF
--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
@@ -6,6 +6,8 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+using Avalonia.Interactivity;
+using Avalonia.Input;
 using Avalonia.Logging;
 using Avalonia.Threading;
 using Markdig;
@@ -81,7 +83,64 @@ public partial class MarkdownRenderer : Control
             if (value is not null)
             {
                 value.Changed += CommitChange;
-                CommitChange(new ObservableStringBuilderChangedEventArgs(0, value.Length, value.Length, value.Version));
+
+                // FORK: a rebind is parsed SYNCHRONOUSLY, right here, and invalidates nothing.
+                //
+                // Two separate hazards, and both need this. A builder swap is what a VIRTUALIZING panel does to
+                // a recycled container — from inside the layout pass that is measuring it.
+                //
+                // 1. Don't invalidate. CommitChange ends in InvalidateArrange(), and invalidating layout from
+                //    inside the pass measuring you is a cycle:
+                //        recycle -> rebind -> InvalidateArrange -> layout pass -> recycle -> ...
+                //    Diagnosed from a managed stack of a live hang: LayoutManager.Measure three deep inside one
+                //    ExecuteLayoutPass, VirtualizingStackPanel.MeasureOverride calling RecycleAllElements every
+                //    pass. Mutating the node tree below already invalidates measure the ordinary way.
+                //
+                // 2. Don't DEFER either — this is the half that reads as "the scroll is fighting me". Deferring
+                //    the parse (posting it, or letting the async render loop take it) means the row measures at
+                //    PLACEHOLDER height and then grows when the parse lands. Under a virtualizing panel that
+                //    growth is a layout loop with a period of two: grown rows shift which item contains the
+                //    viewport's start offset, the anchor flips, and the flipped window recycles fresh renderers
+                //    whose parses land and shift it back. Parsing inline makes the height right on FIRST
+                //    measure, so nothing grows and the oscillation cannot start.
+                //
+                // A REBIND IS NOT STREAMING. The async path above is untouched and keeps its real purpose —
+                // incremental appends while a message streams. The cost here is one Markdig parse per
+                // realization, sub-millisecond for a typical message, on content the user is about to see.
+                var snapshot = value.CaptureSnapshot();
+                var rebind = new ObservableStringBuilderChangedEventArgs(0, value.Length, value.Length, snapshot.Version);
+
+                // ...but ONLY while attached, which is the case this exists for: a recycled container is rebound
+                // from inside a layout pass, and it is already in the tree. Parsing inline while DETACHED builds
+                // the inlines before there is a styled tree to build them into, and Avalonia styles a logical
+                // child when it enters one — so the chips would render with their property DEFAULTS and no
+                // stylesheet would ever reach them. Measured exactly that: a renderer whose MarkdownBuilder is
+                // assigned in an object initializer (before Show()) produced CodeInline runs stuck at the
+                // registered Padding of 2,0 with the host app's sheet never applied.
+                //
+                // Detached, none of the recycle hazards apply and there is nothing to race, so record the change
+                // and let OnAttachedToVisualTree's EnsureRenderLoopStarted render it once there is a tree.
+                if (VisualRoot is null)
+                {
+                    pendingChange = rebind;
+                    return;
+                }
+
+                pendingChange = null;
+                documentNode.Update(
+                    documentNode,
+                    Markdown.Parse(snapshot.Text, pipeline),
+                    rebind,
+                    CancellationToken.None);
+                //
+                // NOT InvalidateTextBlockCache()/ScheduleRenderedTextStateRefresh(): BOTH end in
+                // InvalidateArrange(), which is the very thing this path exists to avoid — calling either from
+                // a rebind puts the recycle cycle straight back, through a different door. Drop the caches and
+                // record the projection version directly; ArrangeCore already calls RefreshRenderedTextState,
+                // so the pass that is arranging this container picks it up with no invalidation at all.
+                _textBlocksCache = null;
+                _selectableBlocksCache = null;
+                _pendingRenderedTextStateVersion = snapshot.Version;
             }
         }
     }


### PR DESCRIPTION
A builder swap is what a **virtualizing panel** does to a recycled container — from inside the layout pass that is measuring it. The setter routes that through `CommitChange`, and two separate things then go wrong.

## 1. Invalidating is a cycle

`CommitChange` ends in `InvalidateArrange()`:

```
recycle → rebind → InvalidateArrange → layout pass → recycle → …
```

Diagnosed from a managed stack of a live hang: `LayoutManager.Measure` three deep inside one `ExecuteLayoutPass`, with `VirtualizingStackPanel.MeasureOverride` calling `RecycleAllElements` every pass. What kept feeding it was Avalonia's own scroll anchoring, which a virtualizing panel enables and which exposes no public off-switch — so it has to be fixed here, and here is the right place regardless: a control shouldn't invalidate layout from inside the pass measuring it.

## 2. Deferring is an oscillation

This is the half that's *felt* rather than hung, and it's why simply not invalidating isn't enough.

Letting the async render loop take the rebind means the row measures at **placeholder height** and grows when the parse lands. Under a virtualizing panel that growth shifts which item contains the viewport's start offset, the anchor flips, and the flipped window recycles fresh renderers whose parses land and shift it back. It reads to a user as the scroll fighting them.

## The change

A rebind is parsed **synchronously** and invalidates **nothing**. Mutating the node tree already invalidates measure the ordinary way, and parsing inline makes the height right on the *first* measure so nothing grows.

Two constraints that aren't obvious from the call sites:

- **`InvalidateTextBlockCache()` and `ScheduleRenderedTextStateRefresh()` also end in `InvalidateArrange()`**, so neither can be used here either. The caches are dropped and the projection version recorded directly; `ArrangeCore`'s `RefreshRenderedTextState` consumes it. A method named `Invalidate…Cache` invalidating *layout* is easy to reach for by accident.
- **Only while attached.** Detached there's no layout pass to reenter and no first measure to get right — and building inlines before the renderer is in a styled tree means Avalonia never styles them. Measured: a renderer whose `MarkdownBuilder` is set in an object initializer produced `CodeInline` runs stuck at their registered `Padding` of `2,0` with the host stylesheet never applying. Detached, the change is recorded and `OnAttachedToVisualTree`'s `EnsureRenderLoopStarted` renders it.

**A rebind is not streaming.** The async path is untouched and keeps its real purpose — incremental appends while a message streams. The cost here is one Markdig parse per realization, sub-millisecond for a typical message, on content the user is about to see.

136 tests pass.
