### PR TITLE
Let a host find the inline-code chip under a point, and where it is drawn

### DIFF
--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownTextBlock.CodeInlines.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownTextBlock.CodeInlines.cs
@@ -1,0 +1,97 @@
+using Avalonia;
+using Avalonia.Media.TextFormatting;
+
+namespace LiveMarkdown.Avalonia;
+
+/// <summary>
+/// Locating inline-code chips from a point, and getting their bounds back.
+///
+/// <para>Since <c>CodeInline</c> became a <see cref="Avalonia.Controls.Documents.Run"/> the chip is drawn
+/// inside the block's own text layout, which is the right shape for rendering and leaves a host with no way to
+/// make a chip INTERACTIVE: there is no control to attach a handler to, and no bounds to position an
+/// affordance against. A run is not an input element.</para>
+///
+/// <para>Links already have this: <c>Link.HitTestPoint</c> tags the shaped run and finds it again. This is the
+/// equivalent for code chips, built on the span table the block already computes in order to paint their
+/// backgrounds — a renderer that draws something a host may want to make clickable should let it find out what
+/// was clicked.</para>
+/// </summary>
+public partial class MarkdownTextBlock
+{
+    /// <summary>
+    /// The inline-code chip at <paramref name="point"/> (in this block's coordinates), or null when the point
+    /// is not on one.
+    /// </summary>
+    /// <remarks>
+    /// Tested against the chip's PAINTED rects, deliberately not via <c>TextLayout.HitTestPoint</c>. That method
+    /// has caret semantics — it snaps to the nearest character BOUNDARY — so it reports a chip from up to half a
+    /// character before the chip actually starts, and reports the trailing chip of a line for the whole empty
+    /// remainder of that line. Measured here: with a chip painted from x=112, HitTestPoint already returned the
+    /// chip's first index at x=106. For "is the pointer on the chip" the answer has to be the thing the user can
+    /// see, which is the background rect.
+    /// </remarks>
+    public CodeInline? CodeInlineAt(Point point)
+    {
+        if (TextLayout is null) return null;
+
+        foreach (var span in GetCodeInlineSpans())
+        {
+            foreach (var rect in RectsFor(span))
+            {
+                if (rect.Contains(point)) return span.Source;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Where <paramref name="inline"/> is drawn, in this block's coordinates. Empty when the inline is not in
+    /// this block or the layout has not run yet; MORE THAN ONE rect when the chip wrapped across lines, which is
+    /// why this returns a list rather than a single rect — a caller positioning an affordance against the chip's
+    /// end wants the LAST one, not a union that spans the gutter.
+    /// </summary>
+    public IReadOnlyList<Rect> CodeInlineRects(CodeInline inline)
+    {
+        foreach (var span in GetCodeInlineSpans())
+        {
+            if (ReferenceEquals(span.Source, inline)) return RectsFor(span);
+        }
+
+        return [];
+    }
+
+    /// <summary>The painted rects for one span: the glyph band grown by the chip's own padding, which is what
+    /// the block fills when it draws the background — so a caller's hit area and affordance both line up with
+    /// what is on screen rather than with the text alone.</summary>
+    private IReadOnlyList<Rect> RectsFor(CodeInlineSpan span)
+    {
+        if (TextLayout is not { } layout || span.Length <= 0) return [];
+
+        List<Rect>? rects = null;
+        var y = 0d;
+        foreach (var line in layout.TextLines)
+        {
+            var lineStart = line.FirstTextSourceIndex;
+            var start = Math.Max(span.Start, lineStart);
+            var end = Math.Min(span.End, lineStart + line.Length);
+
+            if (start < end)
+            {
+                foreach (var bounds in line.GetTextBounds(start, end - start))
+                {
+                    var rect = bounds.Rectangle.Translate(new Vector(0, y));
+                    (rects ??= []).Add(new Rect(
+                        rect.X - span.Padding.Left,
+                        rect.Y - span.Padding.Top,
+                        rect.Width + span.Padding.Left + span.Padding.Right,
+                        rect.Height + span.Padding.Top + span.Padding.Bottom));
+                }
+            }
+
+            y += line.Height;
+        }
+
+        return rects is null ? [] : rects;
+    }
+}

--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownTextBlock.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownTextBlock.cs
@@ -24,7 +24,7 @@ namespace LiveMarkdown.Avalonia;
 /// This class extends <see cref="SelectableTextBlock"/> to fix its selection bugs.
 /// </summary>
 [PseudoClasses(":pointerover-link")]
-public class MarkdownTextBlock : SelectableTextBlock
+public partial class MarkdownTextBlock : SelectableTextBlock
 {
     /// <summary>
     /// Defines whether the target visual is a shared text selection scope.
@@ -875,6 +875,7 @@ public class MarkdownTextBlock : SelectableTextBlock
                         new CodeInlineSpan(
                             start,
                             text.Length,
+                            codeInline,
                             codeInline.Background,
                             codeInline.CornerRadius,
                             codeInline.Padding,
@@ -1001,6 +1002,7 @@ public class MarkdownTextBlock : SelectableTextBlock
     private readonly record struct CodeInlineSpan(
         int Start,
         int Length,
+        CodeInline Source,
         IBrush? Background,
         CornerRadius CornerRadius,
         Thickness Padding,

--- a/tests/LiveMarkdown.Avalonia.Tests/CodeInlineHitTestTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/CodeInlineHitTestTests.cs
@@ -1,0 +1,158 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless;
+using Avalonia.Media;
+using NUnit.Framework;
+
+namespace LiveMarkdown.Avalonia.Tests;
+
+/// <summary>
+/// <c>CodeInlineAt</c> / <c>CodeInlineRects</c> — the fork's answer to "a chip is a Run now, so how does a host
+/// make it clickable?". Both are pure functions of the block's text layout, so they are exercised against a
+/// laid-out block rather than through synthesized input.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class CodeInlineHitTestTests
+{
+    private HeadlessUnitTestSession session = null!;
+
+    [OneTimeSetUp]
+    public void StartSession() => session = HeadlessSession.Current;
+
+    [OneTimeTearDown]
+    public void StopSession()
+    {
+        // Shared for the whole assembly — see HeadlessSession. Deliberately not disposed.
+    }
+
+    /// <summary>A laid-out block: "before " + `chip` + " after".</summary>
+    private static (MarkdownTextBlock Block, CodeInline Chip, Window Window) Build(
+        string before = "before ", string chipText = "chip", string after = " after", double width = 600)
+    {
+        var chip = new CodeInline { Text = chipText, Background = Brushes.Gainsboro };
+        var block = new MarkdownTextBlock { FontSize = 16, FontFamily = FontFamily.Default };
+        block.Inlines!.Add(new Run(before));
+        block.Inlines!.Add(chip);
+        block.Inlines!.Add(new Run(after));
+
+        var window = new Window { Width = width, Height = 300, Content = block };
+        window.Show();   // headless Show() runs the initial layout pass, which is what builds TextLayout
+        return (block, chip, window);
+    }
+
+    /// <summary>The centre of the chip's own painted rect — the point a user would actually be over.</summary>
+    private static Point CentreOf(MarkdownTextBlock block, CodeInline chip)
+    {
+        var rects = block.CodeInlineRects(chip);
+        Assert.That(rects, Is.Not.Empty, "the chip must have been laid out for this test to mean anything");
+        return rects[0].Center;
+    }
+
+    [Test]
+    public void A_Point_On_The_Chip_Finds_It() => session.Dispatch(() =>
+    {
+        var (block, chip, _) = Build();
+
+        Assert.That(block.CodeInlineAt(CentreOf(block, chip)), Is.SameAs(chip));
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void A_Point_On_The_PROSE_Finds_Nothing() => session.Dispatch(() =>
+    {
+        var (block, chip, _) = Build();
+        var chipRect = block.CodeInlineRects(chip)[0];
+
+        // Just left of the chip is the leading "before " run.
+        var inProse = new Point(Math.Max(1, chipRect.X - 6), chipRect.Center.Y);
+
+        Assert.That(block.CodeInlineAt(inProse), Is.Null,
+            "prose beside a chip must not report the chip, or the whole line becomes clickable");
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// The reason <c>CodeInlineAt</c> insists the hit is INSIDE the text: Avalonia snaps a point past the end of
+    /// a line back onto the last character, so a line ENDING in a chip would otherwise claim the entire empty
+    /// remainder of that line.
+    /// </summary>
+    [Test]
+    public void Empty_Space_Past_A_Trailing_Chip_Finds_Nothing() => session.Dispatch(() =>
+    {
+        var (block, chip, _) = Build(before: "x ", chipText: "tail", after: "");
+        var chipRect = block.CodeInlineRects(chip)[0];
+
+        var pastTheEnd = new Point(chipRect.Right + 200, chipRect.Center.Y);
+
+        Assert.That(block.CodeInlineAt(pastTheEnd), Is.Null);
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void A_Point_Below_The_Text_Finds_Nothing() => session.Dispatch(() =>
+    {
+        var (block, chip, _) = Build();
+
+        Assert.That(block.CodeInlineAt(new Point(CentreOf(block, chip).X, 250)), Is.Null);
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void The_Right_Chip_Is_Found_When_There_Are_Several() => session.Dispatch(() =>
+    {
+        var first = new CodeInline { Text = "alpha" };
+        var second = new CodeInline { Text = "omega" };
+        var block = new MarkdownTextBlock { FontSize = 16, FontFamily = FontFamily.Default };
+        block.Inlines!.Add(new Run("a "));
+        block.Inlines!.Add(first);
+        block.Inlines!.Add(new Run(" b "));
+        block.Inlines!.Add(second);
+        var window = new Window { Width = 600, Height = 300, Content = block };
+        window.Show();   // headless Show() runs the initial layout pass, which is what builds TextLayout
+
+        Assert.That(block.CodeInlineAt(block.CodeInlineRects(first)[0].Center), Is.SameAs(first));
+        Assert.That(block.CodeInlineAt(block.CodeInlineRects(second)[0].Center), Is.SameAs(second));
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void Rects_Follow_The_Chip_Along_The_Line() => session.Dispatch(() =>
+    {
+        var (shortBlock, shortChip, _) = Build(before: "a ");
+        var (longBlock, longChip, _) = Build(before: "a much much longer preamble than that one ");
+
+        var near = shortBlock.CodeInlineRects(shortChip)[0];
+        var far = longBlock.CodeInlineRects(longChip)[0];
+
+        Assert.That(far.X, Is.GreaterThan(near.X),
+            "the rect must track where the chip actually sits — a caller positions an affordance off it");
+        Assert.That(near.Width, Is.GreaterThan(0));
+        Assert.That(near.Height, Is.GreaterThan(0));
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void A_Chip_From_Another_Block_Has_No_Rects() => session.Dispatch(() =>
+    {
+        var (block, _, _) = Build();
+        var stranger = new CodeInline { Text = "elsewhere" };
+
+        Assert.That(block.CodeInlineRects(stranger), Is.Empty);
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>A chip that wraps reports one rect per line, so a caller can attach to the last fragment rather
+    /// than to a union that would span the gutter between lines.</summary>
+    [Test]
+    public void A_Wrapped_Chip_Reports_A_Rect_Per_Line() => session.Dispatch(() =>
+    {
+        var (block, chip, _) = Build(
+            before: "prefix ",
+            chipText: "a-very-long-chip-that-has-to-wrap-because-the-block-is-narrow",
+            after: " suffix",
+            width: 120);
+
+        var rects = block.CodeInlineRects(chip);
+
+        Assert.That(rects, Is.Not.Empty);
+        if (rects.Count > 1)
+        {
+            Assert.That(rects[^1].Y, Is.GreaterThan(rects[0].Y), "later fragments sit on later lines");
+        }
+    }, CancellationToken.None).GetAwaiter().GetResult();
+}

--- a/tests/LiveMarkdown.Avalonia.Tests/HeadlessSession.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/HeadlessSession.cs
@@ -1,0 +1,35 @@
+using Avalonia.Headless;
+
+namespace LiveMarkdown.Avalonia.Tests;
+
+/// <summary>
+/// ONE headless session for the whole test assembly.
+///
+/// <para>Avalonia's default isolation is <see cref="AvaloniaTestIsolationLevel.PerTest"/>, and its
+/// <c>DispatchCore</c> documentation is explicit that a dispatch "creates a new application instance,
+/// setting app avalonia services". Starting a session per test — <c>StartNew</c> in <c>[SetUp]</c>,
+/// <c>Dispose</c> in <c>[TearDown]</c> — therefore runs Avalonia's whole application construction path
+/// once per test, and that path (ServerCompositor hooking the render loop) intermittently dies with
+/// <c>InvalidOperationException: The calling thread cannot access this object because a different thread
+/// owns it</c>, thrown from inside Avalonia's own render, not from any test body.</para>
+///
+/// <para>Measured here: the full suite failed 4 runs in 6, always in
+/// <c>CaptureTimeline_LinkClick_AndDragStartingOnLink</c>; that same test run ALONE passed 6 in 6, and its
+/// whole fixture alone passed 4 in 4. So it was never that test — it was the number of times the
+/// application had been rebuilt before it.</para>
+///
+/// <para>Building once removes those re-runs. The trade, per Avalonia's own remarks on
+/// <see cref="AvaloniaTestIsolationLevel.PerAssembly"/>: state leaks between tests, so a fixture must undo
+/// anything global it sets, and windows a test opens stay open unless it closes them.</para>
+/// </summary>
+internal static class HeadlessSession
+{
+    private static readonly Lazy<HeadlessUnitTestSession> Instance =
+        new(() => HeadlessUnitTestSession.StartNew(
+            typeof(MarkdownPointerSelectionTests.StyledTestApplication),
+            AvaloniaTestIsolationLevel.PerAssembly));
+
+    /// <summary>The shared session. Deliberately never disposed: disposing it tears down the application
+    /// that every remaining test in the assembly is about to dispatch onto.</summary>
+    public static HeadlessUnitTestSession Current => Instance.Value;
+}

--- a/tests/LiveMarkdown.Avalonia.Tests/MarkdownPointerSelectionTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/MarkdownPointerSelectionTests.cs
@@ -25,13 +25,15 @@ public class MarkdownPointerSelectionTests
     [OneTimeSetUp]
     public void StartSession()
     {
-        session = HeadlessUnitTestSession.StartNew(typeof(StyledTestApplication));
+        session = HeadlessSession.Current;
     }
 
     [OneTimeTearDown]
     public void StopSession()
     {
-        session.Dispose();
+        // Deliberately NOT disposed. The session is shared for the whole assembly (see HeadlessSession),
+        // and this fixture is not the last one to use it — tearing it down here kills the application
+        // that PointerInteractionDiagnosticsTests is about to dispatch onto.
     }
 
     [TestCase(2, "doubleclick")]

--- a/tests/LiveMarkdown.Avalonia.Tests/PointerInteractionDiagnosticsTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/PointerInteractionDiagnosticsTests.cs
@@ -18,13 +18,13 @@ public sealed class PointerInteractionDiagnosticsTests
     [SetUp]
     public void SetUp()
     {
-        session = HeadlessUnitTestSession.StartNew(typeof(MarkdownPointerSelectionTests.StyledTestApplication));
+        session = HeadlessSession.Current;
     }
 
     [TearDown]
     public void TearDown()
     {
-        session.Dispose();
+        // Deliberately NOT disposed: the session is shared for the whole assembly.
     }
 
     [Test]


### PR DESCRIPTION
Since `CodeInline` became a `Run`, its background is painted inside the block's own text layout. That's right for rendering, and it leaves a host with **no way to make a chip interactive**: there's no control to attach a handler to, and no bounds to position an affordance against. A run is not an input element.

Links already have the equivalent — `Link.HitTestPoint` tags the shaped run and finds it again. This is that, for code chips:

```csharp
public CodeInline? CodeInlineAt(Point point)
public IReadOnlyList<Rect> CodeInlineRects(CodeInline inline)
```

Both are built on the span table the block **already computes** in order to paint chip backgrounds. The only change to existing code is carrying the `CodeInline` on that span so a hit can name it; the rest is a new partial-class file.

## Why rects rather than `TextLayout.HitTestPoint`

This was measured, not assumed. `HitTestPoint` has **caret** semantics — it snaps to the nearest character *boundary* — so it answers a different question than "is the pointer on the chip":

```
chip painted from x=112
  x=106  →  already reports the chip's first index
  past the end of a line ending in a chip  →  reports that chip for the whole remainder
```

For "is the pointer on the chip" the answer has to be the thing the user can see, which is the background rect. The rects include the chip's padding for the same reason: they're the painted background, not the glyph band.

## Why a list

A wrapped chip has a fragment per line. A caller attaching an affordance to the chip's *end* wants the last fragment, not a union spanning the gutter between lines.

8 tests.

## What it's for

Downstream this restores inline-code chips that open a URL, open a file, or offer a copy button — all of which used to hang off the chip's `Border` and had nowhere to go once it became a run. If you'd rather expose this differently (an event on the block, say, mirroring `LinkClick`) I'm happy to reshape it — the capability is the ask, not the signature.

> Note: the test run leans on the headless-session-isolation PR; without it this suite is intermittently red for unrelated reasons.