### PR TITLE
Selection: drop the highlight on a handled press, and never select hidden text

### DIFF
--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.Input.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.Input.cs
@@ -241,7 +241,7 @@ public partial class MarkdownRenderer
         }
 
         TrackSelectionPointer(e);
-        UpdateSelectionRangeFromPoint(e.GetPosition(this));
+        UpdateSelectionRangeFromPoint(point.Position);
 
         e.Handled = true;
 
@@ -997,12 +997,15 @@ public partial class MarkdownRenderer
     {
         // We want all blocks, including nested ones, because hierarchy is handled by
         // GetEffectiveStart/GetEffectiveEnd. DFS order provides the document order.
-        if (scopeRoot is MarkdownRenderer renderer)
-        {
-            return renderer.GetSelectableBlocksInRenderer();
-        }
+        var blocks = scopeRoot is MarkdownRenderer renderer
+            ? renderer.GetSelectableBlocksInRenderer()
+            : scopeRoot.GetSelfAndVisualDescendants().OfType<MarkdownTextBlock>();
 
-        return scopeRoot.GetSelfAndVisualDescendants().OfType<MarkdownTextBlock>();
+        // Skip blocks inside a collapsed branch — a folded section, or a node's hidden alternate view — so
+        // select-all and copy never pick up text the reader cannot see. Filtered HERE rather than inside the
+        // cache above, because visibility changes WITHOUT a document change: an expander collapsing does not
+        // invalidate the block cache, so a filter baked into it would be stale.
+        return blocks.Where(b => b.IsEffectivelyVisible);
     }
 
     private static bool IsNestedBlock(MarkdownTextBlock child) => child.FindAncestorOfType<MarkdownTextBlock>() is not null;

--- a/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
+++ b/src/LiveMarkdown.Avalonia/Controls/MarkdownRenderer.cs
@@ -6,6 +6,8 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+using Avalonia.Interactivity;
+using Avalonia.Input;
 using Avalonia.Logging;
 using TextMateSharp.Grammars;
 
@@ -188,6 +190,19 @@ public partial class MarkdownRenderer : Control
         VisualChildren.Add(documentNode.Control);
 
         AddHandler(KeyDownEvent, HandleKeyDown);
+        // A left press drops the selection, as every OS text surface does. TUNNEL phase with
+        // handledEventsToo, because a press landing on something that HANDLES it — a button, an
+        // expander chevron, an embedded control such as the Mermaid or Svg nodes — never reaches the
+        // bubbling selection logic, and the highlight would just sit there.
+        AddHandler(PointerPressedEvent, ClearSelectionOnPress, RoutingStrategies.Tunnel, handledEventsToo: true);
+    }
+
+    private void ClearSelectionOnPress(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+        if (string.IsNullOrEmpty(SelectedText)) return;
+        ClearSelection(GetAllSelectableBlocksInScope(GetSelectionScopeRoot()));
+        UpdateCanCopy();
     }
 
     /// <inheritdoc/>

--- a/tests/LiveMarkdown.Avalonia.Tests/SelectionClearAndVisibilityTests.cs
+++ b/tests/LiveMarkdown.Avalonia.Tests/SelectionClearAndVisibilityTests.cs
@@ -1,0 +1,117 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using NUnit.Framework;
+
+namespace LiveMarkdown.Avalonia.Tests;
+
+/// <summary>
+/// Two selection contracts a reader notices when they break: a left press drops the highlight even when the
+/// thing pressed handles the event, and select-all never reaches text that is hidden.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class SelectionClearAndVisibilityTests
+{
+    private HeadlessUnitTestSession session = null!;
+
+    [OneTimeSetUp]
+    public void StartSession() => session = HeadlessSession.Current;
+
+    private static (Window Window, MarkdownRenderer Renderer) Build(string markdown)
+    {
+        var renderer = new MarkdownRenderer { MarkdownBuilder = new ObservableStringBuilder(markdown) };
+        var window = new Window { Width = 600, Height = 400, Content = renderer };
+        window.Show();
+        // The renderer's producer parses off the UI thread and publishes back onto it, so a layout pass
+        // alone renders nothing — the dispatcher has to run for the document to arrive.
+        for (var i = 0; i < 60; i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            if (renderer.GetVisualDescendants().OfType<MarkdownTextBlock>().Any()) break;
+            Thread.Sleep(5);
+        }
+        window.UpdateLayout();
+        return (window, renderer);
+    }
+
+    private static PointerPressedEventArgs LeftPress(Control source, Visual root) =>
+        new(source, new Pointer(0, PointerType.Mouse, true), root, default, 0,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+            KeyModifiers.None)
+        {
+            RoutedEvent = InputElement.PointerPressedEvent,
+            Source = source,
+        };
+
+    /// <summary>A press that something else HANDLES — a button, a chevron, an embedded control — still has to
+    /// drop the selection, or the highlight sits there after the reader has clearly moved on.</summary>
+    [Test]
+    public void A_Left_Press_Marked_Handled_Still_Clears_The_Selection() => session.Dispatch(() =>
+    {
+        var (window, renderer) = Build("Some selectable prose to highlight.");
+        renderer.SelectAll();
+        Assert.That(renderer.SelectedText, Is.Not.Empty, "the fixture needs a selection to clear");
+
+        // Stand in for a button, chevron or embedded node that swallows the press: a real control from the
+        // rendered tree as the source, already marked handled before the renderer sees it.
+        var swallow = renderer.GetVisualDescendants().OfType<MarkdownTextBlock>().First();
+        var args = LeftPress(swallow, renderer);
+        args.Handled = true;
+        renderer.RaiseEvent(args);
+
+        Assert.That(renderer.SelectedText, Is.Empty,
+            "a handled press is still a press — the tunnel handler must see it");
+        window.Close();
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    [Test]
+    public void A_Right_Press_Leaves_The_Selection_Alone() => session.Dispatch(() =>
+    {
+        var (window, renderer) = Build("Some selectable prose to highlight.");
+        renderer.SelectAll();
+        var before = renderer.SelectedText;
+
+        var target = (Control)renderer;
+        renderer.RaiseEvent(new PointerPressedEventArgs(
+            target, new Pointer(0, PointerType.Mouse, true), target, default, 0,
+            new PointerPointProperties(RawInputModifiers.RightMouseButton, PointerUpdateKind.RightButtonPressed),
+            KeyModifiers.None)
+        {
+            RoutedEvent = InputElement.PointerPressedEvent,
+            Source = target,
+        });
+
+        Assert.That(renderer.SelectedText, Is.EqualTo(before),
+            "right-click opens a context menu for the selection — dropping it first is useless");
+        window.Close();
+    }, CancellationToken.None).GetAwaiter().GetResult();
+
+    /// <summary>Hidden text must not reach the clipboard. Visibility is evaluated at selection time, not
+    /// cached with the document, because collapsing a section changes it without changing the document.</summary>
+    [Test]
+    public void Select_All_Skips_Text_That_Is_Not_Visible() => session.Dispatch(() =>
+    {
+        var (window, renderer) = Build("Visible paragraph.\n\nSecond paragraph.");
+        renderer.SelectAll();
+        var whenAllVisible = renderer.SelectedText ?? "";
+        Assert.That(whenAllVisible, Does.Contain("Second"), "the fixture needs both paragraphs selectable");
+
+        // Collapse the branch containing the second block, the way a fold or an alternate view does.
+        var blocks = renderer.GetVisualDescendants().OfType<MarkdownTextBlock>().ToList();
+        Assert.That(blocks.Count, Is.GreaterThan(1), "the fixture needs more than one block");
+        blocks[^1].IsVisible = false;
+        window.UpdateLayout();
+
+        renderer.SelectAll();
+
+        Assert.That(renderer.SelectedText ?? "", Does.Not.Contain("Second"),
+            "select-all must not pick up text the reader cannot see");
+        window.Close();
+    }, CancellationToken.None).GetAwaiter().GetResult();
+}


### PR DESCRIPTION
Three fixes to the selection surface, all reader-visible.

## 1. A left press drops the selection, even when something else handles it

Every OS text surface clears the selection on press. The bubbling selection logic only sees presses nothing else claimed, so a press landing on a button, an expander chevron, or an embedded control leaves the old highlight sitting there while the reader has plainly moved on.

Handled in the **tunnel** phase with `handledEventsToo`, which is the only phase that sees those presses at all.

This is not hypothetical for this library's own content: the **Mermaid and Svg nodes host controls that claim a press**, so today the highlight survives a click on a diagram.

## 2. Select-all skips text that is not visible

`GetAllSelectableBlocksInScope` walked every block in the scope regardless of whether the reader could see it, so a collapsed fold or a node's hidden alternate view contributed its text to select-all and to the clipboard.

The filter is applied **at the call** rather than baked into the block cache, because visibility changes *without* a document change: an expander collapsing does not invalidate that cache, so a filter inside it would be stale. The cached fast path is preserved — the filter is lazy on top of it.

## 3. A small one

Reuse the `PointerPoint` already resolved a few lines above instead of calling `GetPosition(this)` again for the same event.

## Tests

3, and they pump the dispatcher rather than only calling `UpdateLayout`. Since the producer parses off the UI thread and publishes back onto it, a layout pass on its own renders nothing — every selection assertion would pass vacuously against an empty tree.

163 tests pass.
